### PR TITLE
Fix typescript return typing

### DIFF
--- a/types/debounce.ts
+++ b/types/debounce.ts
@@ -1,5 +1,10 @@
+export interface DebounceInstance {
+  (): void,
+  cancel(): void,
+}
+
 export interface Debounce {
-  (fn: (...args: any[]) => void, wait: number | string): void
+  (fn: (...args: any[]) => void, wait: number | string): DebounceInstance
 }
 
 declare const debounce: Debounce

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@
  * "modifiers" type - https://github.com/vuejs/vue/blob/fd0eaf92948bb5a4882d538362091fb287d642e3/types/options.d.ts#L184
  */
 
-import debounce from './debounce'
+import debounce, {DebounceInstance} from './debounce'
 
 export interface PluginConfig {
   lock?: boolean
@@ -25,5 +25,5 @@ export interface PluginObject {
 
 declare const pluginObject: PluginObject
 
-export { debounce }
+export { debounce, DebounceInstance }
 export default pluginObject


### PR DESCRIPTION
The typescript return typing for the debounce function declared it to return nothing. This is not true, as it returns a method which can be called, and it also contains a cancel function.