### PR TITLE
v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## v3.1.1
+
+### Fixed
+
+- Erroring out when there were no attributes on your element tag [#71](https://github.com/dhershman1/vue-debounce/issues/71)
+- Potential issue if passed events was just an empty array or string would cause debounce to stop listening all together
+  - This falls back on the value of `listenTo`
+
 ## v3.1.0
 
 ### Improved

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-debounce",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-debounce",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A simple vue directive for debounce",
   "main": "dist/vue-debounce.min.js",
   "types": "types/index.d.ts",

--- a/src/directive.js
+++ b/src/directive.js
@@ -27,13 +27,15 @@ function ensureArray (value) {
 
 // Figures out the event we are using with the bound element
 function mapOutListeningEvents (attrs, listenTo) {
+  // Make sure attributes exist on the element
+  const elEvents = attrs ? attrs['debounce-events'] : []
   // If they set an events attribute that overwrites everything
-  if (attrs) {
+  if (elEvents && elEvents.length > 0) {
     // Since they can send in an array or a string we need to be prepared for both
-    if (Array.isArray(attrs)) {
-      return toLowerMap(attrs)
+    if (Array.isArray(elEvents)) {
+      return toLowerMap(elEvents)
     }
-    return toLowerMap(attrs.split(','))
+    return toLowerMap(elEvents.split(','))
   }
 
   return toLowerMap(ensureArray(listenTo))
@@ -81,7 +83,7 @@ export function getDirective (version = '2', {
         fireonempty: fireOnEmpty,
         cancelonempty: cancelOnEmpty
       }, modifiers)
-      const events = mapOutListeningEvents(vnode.data.attrs['debounce-events'], listenTo)
+      const events = mapOutListeningEvents(vnode.data.attrs, listenTo)
       const fn = debounce(e => {
         debouncedFn(e.target.value, e)
       }, timer)


### PR DESCRIPTION
## Fixed

- Erroring out when there were no attributes on your element tag: #71 
- Potential issue if passed events was just an empty array or string would cause debounce to stop listening all together
  - This falls back on the value of `listenTo`
