### PR TITLE
Add exports field to package.json for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "4.0.0",
   "description": "A simple vue directive for debounce",
   "main": "dist/vue-debounce.min.js",
+  "exports": {
+    "import": "./dist/vue-debounce.min.mjs",
+    "require": "./dist/vue-debounce.min.js"
+  },
   "types": "types/index.d.ts",
   "scripts": {
     "test": "tape -r esm tests/test.js | tap-on",


### PR DESCRIPTION
## Fixed

- Added an `exports` field to package.json so that ESM import will work.

### Details

Currently, when using ESM import (without converting to CommonJS using the module bundler), it does not seem to work.
```shell
$ cd /path/to/dir
$ npm i vue-debounce
```
```js
// index.mjs
import { debounce } from 'vue-debounce'
console.log(debounce)
```
```shell
$ node index.mjs
file:///path/to/dir/index.mjs:1
import { debounce } from 'vue-debounce'
         ^^^^^^^^
SyntaxError: Named export 'debounce' not found. The requested module 'vue-debounce' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'vue-debounce';
const { debounce } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:124:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:190:5)

Node.js v18.15.0
```
This is probably because the `main` field in package.json points to the `dist/vue-debounce.min.js` output for CommonJS.
https://github.com/dhershman1/vue-debounce/blob/5fb4bd4e9fc13845fefb3e584a131f468406a871/package.json#L5

CommonJS require is working fine.
```js
// index.cjs
const { debounce } = require('vue-debounce')
console.log(debounce)
```
```shell
$ node index.cjs
[Function: r] # => No Error
```

ESM import will also work if we specify the mjs file directly.
However, it is not clear to the user, and when using typescript, the type information cannot be referenced.
```js
// index2.mjs
import { debounce } from 'vue-debounce/dist/vue-debounce.min.mjs'
console.log(debounce)
```
```shell
$ node index2.mjs
[Function: e] # => No Error
```

This problem could be solved by using the Conditional exports feature of Node.js.
It will work with both ESM and CommonJS.
https://nodejs.org/docs/latest-v18.x/api/packages.html#packages_conditional_exports
```shell
# When adding the exports field:
$ node index.mjs
[Function: e] # => No Error

$ node index.cjs
[Function: r] # => No Error

# *Note that an error will occur if the mjs file is specified directly.
$ node index2.mjs
node:internal/errors:490
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './dist/vue-debounce.min.mjs' is not defined by "exports" in /path/to/dir/node_modules/vue-debounce/package.json imported from /path/to/dir/index2.mjs
    at new NodeError (node:internal/errors:399:5)
    at exportsNotFound (node:internal/modules/esm/resolve:361:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:697:9)
    at packageResolve (node:internal/modules/esm/resolve:872:14)
    at moduleResolve (node:internal/modules/esm/resolve:938:20)
    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:77:40) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}

Node.js v18.15.0
```

I have checked with the following versions, but it should work with older versions of Node.js.
Node.js v18.15.0
vue-debounce 4.0.0

Thank you.